### PR TITLE
feat:AI도서 등록 처리시 출판사, 도서-작가 트랜잭션 처리

### DIFF
--- a/src/main/java/com/nhnacademy/book/dto/book/BookCreateRequest.java
+++ b/src/main/java/com/nhnacademy/book/dto/book/BookCreateRequest.java
@@ -9,6 +9,7 @@ public record BookCreateRequest(
         String bookName,
         String bookDescription,
         String bookPublisher,
+        String bookAuthor,
         LocalDate bookPublicationDate,
         String bookIndex,
         boolean bookPackaging,

--- a/src/main/java/com/nhnacademy/book/repository/AuthorRepository.java
+++ b/src/main/java/com/nhnacademy/book/repository/AuthorRepository.java
@@ -3,5 +3,9 @@ package com.nhnacademy.book.repository;
 import com.nhnacademy.book.entity.Author;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface AuthorRepository extends JpaRepository<Author, Long> {
+    Optional<Author> findByAuthorName(String authorName);
+
 }

--- a/src/main/java/com/nhnacademy/book/repository/PublisherRepository.java
+++ b/src/main/java/com/nhnacademy/book/repository/PublisherRepository.java
@@ -3,5 +3,9 @@ package com.nhnacademy.book.repository;
 import com.nhnacademy.book.entity.Publisher;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PublisherRepository extends JpaRepository<Publisher, Long> {
+
+    Optional<Publisher> findByPublisherName(String publisherName);
 }

--- a/src/main/java/com/nhnacademy/book/service/BookService.java
+++ b/src/main/java/com/nhnacademy/book/service/BookService.java
@@ -30,4 +30,6 @@ public interface BookService {
 
     // 도서 수량
     public void deductStock(Long bookId, int quantity);
+
+    int calculateSalePrice(int regularPrice, double discountRate);
 }

--- a/src/main/java/com/nhnacademy/book/service/strategy/impl/AladinBookSearchStrategy.java
+++ b/src/main/java/com/nhnacademy/book/service/strategy/impl/AladinBookSearchStrategy.java
@@ -3,6 +3,7 @@ package com.nhnacademy.book.service.strategy.impl;
 import com.nhnacademy.book.aladin.AladinResponse;
 import com.nhnacademy.book.dto.book.BookCreateRequest;
 import com.nhnacademy.book.entity.BookState;
+import com.nhnacademy.book.service.BookService;
 import com.nhnacademy.book.service.strategy.BookSearchStrategy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +21,9 @@ import java.time.format.DateTimeFormatter;
 @RequiredArgsConstructor
 public class AladinBookSearchStrategy implements BookSearchStrategy {
     private final RestTemplate restTemplate;
+    private static final double DEFAULT_DISCOUNT_RATE = 10.0;
+    private final BookService bookService;
+
 
     @Value("${aladin.api.ttb-key}") //키 만료 된듯.
     private String ttbKey;
@@ -65,11 +69,12 @@ public class AladinBookSearchStrategy implements BookSearchStrategy {
         String index = (item.subInfo() != null && item.subInfo().toc() != null) ? item.subInfo().toc() : "";
 
         int noDiscountRate = item.priceStandard();
+        int salePrice = bookService.calculateSalePrice(noDiscountRate, DEFAULT_DISCOUNT_RATE);
 
-        return new BookCreateRequest(
-                item.isbn(), item.title(), item.description(), item.publisher(),
+        return  new BookCreateRequest(
+                item.isbn(), item.title(), item.description(), item.publisher(),item.author(),
                 pubDate, index, true, BookState.ON_SALE, 0,
-                item.priceStandard(), noDiscountRate, item.cover()
+                item.priceStandard(), salePrice, item.cover()
         );
     }
 }

--- a/src/main/java/com/nhnacademy/book/service/strategy/impl/GeminiBookEnrichmentStrategy.java
+++ b/src/main/java/com/nhnacademy/book/service/strategy/impl/GeminiBookEnrichmentStrategy.java
@@ -109,7 +109,7 @@ public class GeminiBookEnrichmentStrategy implements BookEnrichStrategy {
             return new BookCreateRequest(
                     original.isbn(), original.bookName(),
                     newDescription, // AI 설명 적용
-                    original.bookPublisher(), original.bookPublicationDate(),
+                    original.bookPublisher(), original.bookAuthor(), original.bookPublicationDate(),
                     newIndex,       // AI 목차 적용
                     original.bookPackaging(), original.bookState(), original.bookStock(),
                     original.bookRegularPrice(), original.bookSalePrice(), original.bookImage()

--- a/src/main/resources/static/book-register.html
+++ b/src/main/resources/static/book-register.html
@@ -78,6 +78,10 @@
                                         <input type="text" class="form-control" id="bookPublisher">
                                     </div>
                                     <div class="col">
+                                        <label class="form-label">작가</label>
+                                        <input type="text" class="form-control" id="bookAuthor" placeholder="여러 명일 경우 쉼표(,) 구분">
+                                    </div>
+                                    <div class="col">
                                         <label class="form-label">출판일</label>
                                         <input type="date" class="form-control" id="bookPublicationDate">
                                     </div>
@@ -156,6 +160,10 @@
         document.getElementById('isbn').value = data.isbn || '';
         document.getElementById('bookName').value = data.bookName || '';
         document.getElementById('bookPublisher').value = data.bookPublisher || '';
+
+        // [수정됨] 작가 정보 채우기
+        document.getElementById('bookAuthor').value = data.bookAuthor || '';
+
         document.getElementById('bookPublicationDate').value = data.bookPublicationDate || '';
         document.getElementById('bookRegularPrice').value = data.bookRegularPrice || 0;
         document.getElementById('bookSalePrice').value = data.bookSalePrice || 0;
@@ -198,6 +206,10 @@
             bookName: document.getElementById('bookName').value,
             bookDescription: document.getElementById('bookDescription').value,
             bookPublisher: document.getElementById('bookPublisher').value,
+
+            // [수정됨] 작가 정보 포함
+            bookAuthor: document.getElementById('bookAuthor').value,
+
             bookPublicationDate: document.getElementById('bookPublicationDate').value,
             bookIndex: document.getElementById('bookIndex').value,
             bookPackaging: true,


### PR DESCRIPTION
### feat : aI 도서 등록시 출판사 null 처리 해결 
-> 도서 등록시 알라딘에서 가져온 도서 정보의 출판사가 이미 우리 db에 있다면 db에서 찾아서 할당, 아니라면 새로운 출판사 정보를 만들고 그 정보를 도서에 매핑

### feat : 도서-작가 처리
-> 도서 등록시 작가가 우리 db에 존재한다면 db에서 해당 작가를 찾아서 도서-작가 테이블에 매핑 아니라면?  새로운 작가 정보를 만들고 이를 도서-작가 테이블에 매핑

### feat  : 도서 판매가 정의
-> 도서 등록시 정가에서 10%를 깐 가격이 판매가로 지정되게 로직 구현.

@gemini-code-assist
추가적으로 도서 등록시 도서나 태그나 카테고리는 어떻게 처리해서 매핑시켜야 할지?
서비스 로직을 좀 더 분리시킬 방법은 없는지? 할인율이 저렇게 공용 메서드로 사용하는 것이 바람직한가?
그 외에도 다른 트랜잭션 처리가 누락된 곳은 없는지?